### PR TITLE
Fixed null reference bug that breaks theme if user has no picture set.

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -1,5 +1,5 @@
 [theme]
-name=Test Theme
+name=bevel
 description=Test Webkit Theme
 engine=lightdm-webkit-greeter
 url=index.html

--- a/js/script.js
+++ b/js/script.js
@@ -36,8 +36,10 @@ $(document).ready(function() {
     $entry.data('user', user);
     
     var $bubble = $('<div />', {class: 'bubble'}).css({backgroundColor: palette[i]});
-        if(user.image.length > 0) 
+    if(user.image) {   
+    if(user.image.length > 0) 
             $bubble.css({'background-image': 'url('+user.image+')'});
+    }
         $bubble.appendTo($entry);
     var $username = $('<div />', {class: 'user-name'}).text(user.display_name).appendTo($entry);
 


### PR DESCRIPTION
Basically by not checking if the user.image is null the whole theme breaks and lightdm defaults to the fallback theme.  I'm not sure if this is because this code hasn't been updated for 6 years or what. But now it should work for anyone trying to use this theme.

I also set the theme name to bevel in the index.theme file.